### PR TITLE
Disable mitm in case of an exception

### DIFF
--- a/lib/failure.js
+++ b/lib/failure.js
@@ -129,6 +129,7 @@ var injectFailure = function (fn) {
       return fn.apply(this, arguments);
     } catch (ex) {
       console.log(ex);
+      clearMitm();
       throw ex;
     }
   };


### PR DESCRIPTION
If there is an exception during setting up the rules for `mitm`, the `mitm` stays enabled blocking all traffic.

We used a wrong regular expression, for example `*githubusercontent*`, which leads to the following exception.

```
2024-07-03T12:32:54.054Z	9a9ffda4-19ee-4be3-bb8f-d0da8791da54	ERROR	Invoke Error 	
{
    "errorType": "SyntaxError",
    "errorMessage": "Invalid regular expression: /*githubusercontent*/: Nothing to repeat",
    "stack": [
        "SyntaxError: Invalid regular expression: /*githubusercontent*/: Nothing to repeat",
        "    at new RegExp (<anonymous>)",
        "    at /var/task/main.js:112:27",
        "    at Array.forEach (<anonymous>)",
        "    at Runtime.handler (/var/task/main.js:111:27)",
        "    at processTicksAndRejections (node:internal/process/task_queues:96:5)"
    ]
}
```

The exception happens after `mitm.enable()` and with this PR the `mitm` should be disabled via the catch block.